### PR TITLE
types, kindly reserve 0x81,0x82 for mLRS

### DIFF
--- a/crsf.md
+++ b/crsf.md
@@ -1093,6 +1093,8 @@ MSP frame over CRSF Payload packing:
 
 ## __0x80 Ardupilot reserved__
 
+## __0x81, 0x82 mLRS reserved__
+
 ## __0xAA CRSF MAVLink envelope__
 
 - CRSF MAVLink envelope is designed to transfer MAVLink protocol over CRSF routers. It supports both MAVLink2 and MAVLink1 frames. 


### PR DESCRIPTION
@tbs-trappy @kamik2 

On behalf of the mLRS project I want to very kindly ask to reserve the types 0x81, 0x82 for said project.

The usage is similar to the 0x80 type reserved for ArduPilot, to use it for home-brewed stuff, which in case of mLRS is crucial for supporting Lua scripts on the radio.
