### PR TITLE
chore: Add gitignore paths for common editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Visual Studio Settings
+.vs/
+
+# VS Code Settings
+.vscode/
+
+# VIM files
+*.swp
+*.swo
+
+# Sublime Text files
+*.sublime-project
+*.sublime-workspace


### PR DESCRIPTION
This PR adds a `.gitignore` file with paths to project files of commonly used code editors (e.g., VS Code, Visual Studio etc)