### PR TITLE
Add QNE, QNH, QFE altitudes

### DIFF
--- a/crsf.md
+++ b/crsf.md
@@ -26,6 +26,7 @@
   - [0x07 Variometer Sensor](#0x07-variometer-sensor)
   - [0x08 Battery Sensor](#0x08-battery-sensor)
   - [0x09 Barometric Altitude & Vertical Speed](#0x09-barometric-altitude--vertical-speed)
+  - [0x0A Airspeed](#0x0a-airspeed)
   - [0x0B Heartbeat](#0x0b-heartbeat)
   - [0x0F Discontinued](#0x0f-discontinued)
   - [0x10 VTX Telemetry](#0x10-vtx-telemetry)
@@ -364,6 +365,12 @@ int16_t get_vertical_speed_cm_s (int8_t vertical_speed_packed){
 ```
 
 Such constants give ±2500cm/s range and 3cm/s precision at low speeds and 70cm/s precision at speed about 25m/s;
+
+## 0x0A Airspeed
+
+```cpp
+    uint16_t speed;             // Airspeed in 0.1 * km/h (hectometers/h)
+```
 
 ## 0x0B Heartbeat
 

--- a/crsf.md
+++ b/crsf.md
@@ -309,12 +309,12 @@ These frame allows sending altitudes and vertical speed in a bit-efficient way. 
 ```cpp
     uint16_t altitude_qfe_packed;   // Altitude above start (calibration) point
                                     // See description below.
-    int8_t   vertical_speed_packed; // vertical speed. See description below.
-    uint16_t altitude_qne_packed;   // Altitude from barometer for normal pressure (101300 Pa).
+    int8_t   vertical_speed_packed; // (optional) vertical speed. See description below.
+    uint16_t altitude_qne_packed;   // (optional) Altitude from barometer for normal pressure (101300 Pa).
                                     // See description below.
 ```
 
-Altitude QFE (relative to the start) is calculated by the flight controller, usually using a barometer and GPS according to its own algorithms. The zero point is altitude at which the ARM is produced. Calc depends on MSB (bit 15):
+Altitude QFE (relative to the start) is calculated by the flight controller, usually using a barometer or(and) GPS according to its own algorithms. The zero point is altitude at which the ARM is produced. Calc depends on MSB (bit 15):
 
 - MSB = 0: altitude is in decimeters - 10000dm offset (so 0 represents -1000m; 10000 represents 0m (starting altitude); 0x7fff represents 2276.7m);
 - MSB = 1: altitude is in meters. Without any offset.


### PR DESCRIPTION
The frame 0x09 has the name "Barometric altitude and vertical velocity", but it actually displays the altitude above the takeoff point. Moreover, it is not always calculated using only a barometer.

For an unambiguous interpretation of altitudes, I suggest using the terminology of "big" aviation and extend frame:
 - uint16 - attitude relative fieldset, QNF (as now, FC may calc use baro and gps)
 - uint8 - vertical speed (as now)
 - uint16 - attitude relative normal pressure, QNE (FC must calc use baro only and pressure 101300 Pa for sea level)
 
Last altitude need for flights  above 2000-3000 meters.

Attitude in GPS frame, I suggest calling QNH (because this is the altitude above sea level)
