### PR TITLE
Frame type 0X0E: report battery cell voltages, or a group of associated voltages from a single source

### DIFF
--- a/crsf.md
+++ b/crsf.md
@@ -399,13 +399,17 @@ Frame type used to transmit temperature telemetry data from the vehicle to the t
     int16_t     temperature[];        // up to 20 temperature values in deci-degree (tenths of a degree) Celsius (e.g., 250 = 25.0°C, -50 = -5.0°C)
 ```
 
-## 0x0E Cells Sensor
+## 0x0E Voltages (or "Voltage Group")
 
-Frame type sends each cell's Voltage from the craft's main battery to the transmitter. Sensors handle up to 29s batteries, with multiple sensors for multi-battery crafts.
+Used to transmit voltage telemetry from the craft to the transmitter. Can be used to report battery cell voltages, or a group of associated voltages from a single source.
+
+Interpretation of the type of voltages is dependent on the source_id selected for reporting:
+- 0..127: Interpret as cell voltages of a single battery, up to 29S. Multiple batteries may be reported using multiple 0x0E frames with different source_ids. e.g. 0 = battery 1 cells, 1 = battery 2 cells, etc,
+- 128..255: Interpret as general voltages measured from a single source. For example, an ESC might report incoming voltage, BEC output voltage, and MCU voltage as a single source_id and use additional source_ids for reporting multiple ESCs. e.g. 128 = ESC 1, 129 = ESC 2, etc
 
 ```cpp
-    uint8_t    Cell_Sensor_source_id;    // Identifies the source of the Main_battery data (e.g., 0 = battery 1, 1 = battery 2, etc.)
-    uint16_t    Cell_Sensor_value[];      // up to 29 cell values in a resolution of a thousandth of a Volt (e.g. 3.850V = 3850)
+    uint8_t     Voltage_source_id;  // source of the voltages
+    uint16_t    Voltage_values[];   // Up to 29 voltages in millivolts (e.g. 3.850V = 3850)
 ```
 
 ## 0x0F Discontinued


### PR DESCRIPTION
This joint RadioMaster, EdgeTX, ExpressLRS proposal enables the 0X0E frame to be used to report battery cell voltages, or a group of associated voltages from a single source.

The following example shows a craft with two cells sensor devices (Voltage_Sensor_source_ids < 128) connected to the balancer connectors of a 14s main battery (2 x 7s in series). The example also assumes one bad cell in the second 7s battery. The motor is controlled by an ESC providing battery and BEC voltage (Voltage_Sensor_source_id>127).

0X0E frames sent:

1. Voltage_Sensor_source_id = 0, Voltage_Sensor_value = { 4180, 4190, 4180, 4170, 4180, 4190, 4190 }
2. Voltage_Sensor_source_id = 1, Voltage_Sensor_value = { 4170, 4180, 4180, 4180, 3630, 4190, 4190 }
3. Voltage_Sensor_source_id = 250, Voltage_Sensor_value = { 57650, 8050 }

Frames 1 and 2 report two _Cels_ sensors each containing 7 voltages. Frame 3 reports two discrete Volt sensors (ESC main battery voltage and BEC voltage). Calculated sensor cl1l using the first _Cels_ sensor shows the lowest battery cell voltage of the first 7s battery. Calculated sensor cl2l using the second _Cels_ sensor shows the lowest (faulty) battery cell voltage of the second 7s battery.

![image](https://github.com/user-attachments/assets/56053a1b-9344-4d45-ae75-dce84c9584e3)

